### PR TITLE
Added default priority of 25 for indexers added to Radarr

### DIFF
--- a/src/interfaces/RadarrEntry.ts
+++ b/src/interfaces/RadarrEntry.ts
@@ -4,6 +4,7 @@ export interface RadarrEntry {
     supportsRss: boolean,
     supportsSearch: boolean,
     protocol: string,
+    priority: number,
     implementationName: 'Torznab',
     implementation: 'Torznab',
     configContract: 'TorznabSettings',

--- a/src/services/radarr.ts
+++ b/src/services/radarr.ts
@@ -42,6 +42,7 @@ export class Radarr extends Service {
         this.indexerSpecificConfiguration(indexer, supportedCategories, []);
 
         return {
+            priority: 25,
             enableRss: true,
             enableSearch: true,
             supportsRss: true,


### PR DESCRIPTION
I noticed that all trackers are added to Radarr with priority 0.
This minor change will cause them to be added with priority 25 (which matches the behavior on Sonarr). 